### PR TITLE
記事詳細表示機能追加#3

### DIFF
--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -21,6 +21,7 @@
         "react-dom": "^18.3.1",
         "react-markdown": "^9.0.1",
         "react-redux": "^9.1.2",
+        "react-router-dom": "^7.0.1",
         "react-scripts": "5.0.1",
         "sass": "^1.80.4",
         "typescript": "^4.9.5",
@@ -4753,6 +4754,12 @@
         "@types/express-serve-static-core": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
     },
     "node_modules/@types/debug": {
       "version": "4.1.12",
@@ -16026,6 +16033,55 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.0.1.tgz",
+      "integrity": "sha512-WVAhv9oWCNsja5AkK6KLpXJDSJCQizOIyOd4vvB/+eHGbYx5vkhcmcmwWjQ9yqkRClogi+xjEg9fNEOd5EX/tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cookie": "^0.6.0",
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0",
+        "turbo-stream": "2.4.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.0.1.tgz",
+      "integrity": "sha512-duBzwAAiIabhFPZfDjcYpJ+f08TMbPMETgq254GWne2NW1ZwRHhZLj7tpSp8KGb7JvZzlLcjGUnqLxpZQVEPng==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -17008,6 +17064,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -18378,6 +18440,12 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/turbo-stream": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/turbo-stream/-/turbo-stream-2.4.0.tgz",
+      "integrity": "sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==",
+      "license": "ISC"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -23,6 +23,7 @@
         "react-redux": "^9.1.2",
         "react-router-dom": "^7.0.1",
         "react-scripts": "5.0.1",
+        "remark-gfm": "^4.0.0",
         "sass": "^1.80.4",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -12701,6 +12702,44 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.1.tgz",
+      "integrity": "sha512-SG21kZHGC3XRTSUhtofZkBzZTJNM5ecCi0SK2IMKmSXR8vO3peL+kb1O0z7Zl83jKtutG4k5Wv/W7V3/YHvzPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
@@ -12719,6 +12758,107 @@
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0",
         "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.0.0.tgz",
+      "integrity": "sha512-dgQEX5Amaq+DuUqf26jJqSK9qgixgd6rYDHAv4aTBuA92cTknZlKpPfa86Z/s8Dj8xsAQpFfBmPUHWJBWqS4Bw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.0.0.tgz",
+      "integrity": "sha512-5jOT2boTSVkMnQ7LTrd6n/18kqwjmuYqo7JUPe+tRCY6O7dAuTFMtTPauYYrMPpox9hlN0uOx/FL8XvEfG9/mQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -12981,6 +13121,127 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.0.tgz",
+      "integrity": "sha512-Ub2ncQv+fwD70/l4ou27b4YzfNaCJOvyX4HxXU15m7mpYY+rjuWzsLIPZHJL253Z643RpbcP1oeIJlQ/SKW67g==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -16352,6 +16613,24 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.0.tgz",
+      "integrity": "sha512-U92vJgBPkbw4Zfu/IiW2oTZLSL3Zpv+uI7My2eq8JxKgqraFdU8YUGicEJCEgSbeaG+QDFqIcwwfMTOEelPxuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
@@ -16379,6 +16658,21 @@
         "mdast-util-to-hast": "^13.0.0",
         "unified": "^11.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/front/package.json
+++ b/front/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^18.3.1",
     "react-markdown": "^9.0.1",
     "react-redux": "^9.1.2",
+    "react-router-dom": "^7.0.1",
     "react-scripts": "5.0.1",
     "sass": "^1.80.4",
     "typescript": "^4.9.5",

--- a/front/package.json
+++ b/front/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^9.1.2",
     "react-router-dom": "^7.0.1",
     "react-scripts": "5.0.1",
+    "remark-gfm": "^4.0.0",
     "sass": "^1.80.4",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -34,9 +34,9 @@ function App() {
         <div>
             {user ? (
                 <>
-                    <Header />
-                    <Search />
                     <Router>
+                        <Header />
+                        <Search />
                         <Routes>
                             <Route path="/" element={<List />} />
                             <Route

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -7,6 +7,8 @@ import { auth } from "./firebase";
 import { login, logout } from "./features/userSlice";
 import Header from "./components/header/header";
 import Search from "./components/search/search";
+import Detail from "./components/detail/detail";
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 
 function App() {
     const user = useAppSelector((state) => state.user.user);
@@ -34,7 +36,12 @@ function App() {
                 <>
                     <Header />
                     <Search />
-                    <List />
+                    <Router>
+                        <Routes>
+                            <Route path="/" element={<List />} />
+                            <Route path="/detail" element={<Detail />} />
+                        </Routes>
+                    </Router>
                 </>
             ) : (
                 <Login />

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -39,7 +39,10 @@ function App() {
                     <Router>
                         <Routes>
                             <Route path="/" element={<List />} />
-                            <Route path="/detail" element={<Detail />} />
+                            <Route
+                                path="/detail/:postId"
+                                element={<Detail />}
+                            />
                         </Routes>
                     </Router>
                 </>

--- a/front/src/components/detail/detail.scss
+++ b/front/src/components/detail/detail.scss
@@ -10,13 +10,13 @@
     .article-title {
         font-size: 2rem;
         color: #333;
-        margin-bottom: 10px;
+        margin-bottom: 15px;
     }
 
     .article-author {
         font-size: 0.9rem;
         color: #007bff;
-        margin-bottom: 10px;
+        margin-bottom: 15px;
     }
 
     .article-tags {
@@ -28,46 +28,83 @@
     .article-content {
         font-size: 1rem;
         color: #666;
-        line-height: 1.6;
-        margin-bottom: 20px;
+        line-height: 1.8;
+        margin-bottom: 30px;
 
         p {
-            margin-bottom: 15px;
+            margin-bottom: 20px;
         }
     }
 
     .interaction-bar {
         display: flex;
         gap: 10px;
+        margin-bottom: 30px;
 
-        .like-button,
-        .favorite-button {
+        .like-button {
             padding: 10px 20px;
             font-size: 1rem;
             color: #ffffff;
+            background-color: #007bff;
             border: none;
             border-radius: 5px;
             cursor: pointer;
             transition: background-color 0.3s;
 
             &:hover {
-                opacity: 0.8;
-            }
-        }
-
-        .like-button {
-            background-color: #007bff;
-
-            &:hover {
                 background-color: #0056b3;
             }
         }
+    }
 
-        .favorite-button {
-            background-color: #ff9800;
+    .comment-section {
+        .comment-title {
+            font-size: 1.5rem;
+            color: #333;
+            margin-bottom: 15px;
+        }
 
-            &:hover {
-                background-color: #e68a00;
+        .comment-form {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+            margin-bottom: 20px;
+
+            .comment-input {
+                width: 100%;
+                height: 80px;
+                padding: 10px;
+                border: 1px solid #e0e0e0;
+                border-radius: 5px;
+                font-size: 1rem;
+                resize: none;
+            }
+
+            .comment-button {
+                align-self: flex-end;
+                padding: 10px 20px;
+                background-color: #007bff;
+                color: #ffffff;
+                border: none;
+                border-radius: 5px;
+                font-size: 1rem;
+                cursor: pointer;
+                transition: background-color 0.3s;
+
+                &:hover {
+                    background-color: #0056b3;
+                }
+            }
+        }
+
+        .comment-list {
+            .comment-item {
+                padding: 10px;
+                margin-bottom: 10px;
+                background-color: #f8f9fa;
+                border: 1px solid #e0e0e0;
+                border-radius: 5px;
+                font-size: 0.9rem;
             }
         }
     }
@@ -82,10 +119,23 @@
             font-size: 1.5rem;
         }
 
-        .interaction-bar .like-button,
-        .interaction-bar .favorite-button {
+        .article-content {
+            font-size: 0.9rem;
+            line-height: 1.6;
+        }
+
+        .interaction-bar .like-button {
             font-size: 0.9rem;
             padding: 8px 16px;
+        }
+
+        .comment-form .comment-button {
+            font-size: 0.9rem;
+            padding: 8px 16px;
+        }
+
+        .comment-list .comment-item {
+            font-size: 0.85rem;
         }
     }
 }

--- a/front/src/components/detail/detail.scss
+++ b/front/src/components/detail/detail.scss
@@ -1,0 +1,91 @@
+.article-detail {
+    max-width: 800px;
+    margin: 100px auto 20px; // ヘッダー分の余白を追加
+    padding: 20px;
+    background-color: #ffffff;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+
+    .article-title {
+        font-size: 2rem;
+        color: #333;
+        margin-bottom: 10px;
+    }
+
+    .article-author {
+        font-size: 0.9rem;
+        color: #007bff;
+        margin-bottom: 10px;
+    }
+
+    .article-tags {
+        font-size: 0.9rem;
+        color: #6c757d;
+        margin-bottom: 20px;
+    }
+
+    .article-content {
+        font-size: 1rem;
+        color: #666;
+        line-height: 1.6;
+        margin-bottom: 20px;
+
+        p {
+            margin-bottom: 15px;
+        }
+    }
+
+    .interaction-bar {
+        display: flex;
+        gap: 10px;
+
+        .like-button,
+        .favorite-button {
+            padding: 10px 20px;
+            font-size: 1rem;
+            color: #ffffff;
+            border: none;
+            border-radius: 5px;
+            cursor: pointer;
+            transition: background-color 0.3s;
+
+            &:hover {
+                opacity: 0.8;
+            }
+        }
+
+        .like-button {
+            background-color: #007bff;
+
+            &:hover {
+                background-color: #0056b3;
+            }
+        }
+
+        .favorite-button {
+            background-color: #ff9800;
+
+            &:hover {
+                background-color: #e68a00;
+            }
+        }
+    }
+}
+
+// レスポンシブ対応
+@media (max-width: 600px) {
+    .article-detail {
+        padding: 15px;
+
+        .article-title {
+            font-size: 1.5rem;
+        }
+
+        .interaction-bar .like-button,
+        .interaction-bar .favorite-button {
+            font-size: 0.9rem;
+            padding: 8px 16px;
+        }
+    }
+}

--- a/front/src/components/detail/detail.tsx
+++ b/front/src/components/detail/detail.tsx
@@ -20,7 +20,19 @@ const Detail = () => {
             </div>
             <div className="interaction-bar">
                 <button className="like-button">👍 いいね</button>
-                <button className="favorite-button">⭐ お気に入り</button>
+            </div>
+            <div className="comment-section">
+                <h2 className="comment-title">コメント</h2>
+                <div className="comment-form">
+                    <textarea
+                        placeholder="コメントを入力してください"
+                        className="comment-input"
+                    />
+                    <button className="comment-button">コメントを追加</button>
+                </div>
+                <div className="comment-list">
+                    <div className="comment-item">コメントを残しています。</div>
+                </div>
             </div>
         </div>
     );

--- a/front/src/components/detail/detail.tsx
+++ b/front/src/components/detail/detail.tsx
@@ -1,7 +1,31 @@
 import React from "react";
 import "./detail.scss";
+import {
+    collection,
+    DocumentData,
+    documentId,
+    query,
+    Query,
+    where,
+} from "firebase/firestore";
+import { db } from "../../firebase";
+import useCollection from "../../hooks/useCollection";
+import { useParams } from "react-router-dom";
 
 const Detail = () => {
+    let { postId } = useParams();
+    console.log(`postId:${postId}`);
+
+    const collectionPostsDetailRef: Query<DocumentData> = query(
+        collection(db, "posts"),
+        where(documentId(), "==", postId)
+    );
+
+    const { data: articleData, error } = useCollection(
+        collectionPostsDetailRef
+    );
+    console.log(JSON.stringify(articleData));
+
     return (
         <div className="article-detail">
             <h1 className="article-title">記事タイトル</h1>

--- a/front/src/components/detail/detail.tsx
+++ b/front/src/components/detail/detail.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import "./detail.scss";
+
+const Detail = () => {
+    return (
+        <div className="article-detail">
+            <h1 className="article-title">記事タイトル</h1>
+            <p className="article-author">著者名</p>
+            <p className="article-tags">#タグ1 #タグ2 #タグ3</p>
+            <div className="article-content">
+                <p>
+                    これは記事の詳細な内容です。段落が続き、さらに詳しい説明が表示されます。Lorem
+                    ipsum dolor sit amet, consectetur adipiscing elit. Integer
+                    nec odio. Praesent libero.
+                </p>
+                <p>
+                    Sed cursus ante dapibus diam. Sed nisi. Nulla quis sem at
+                    nibh elementum imperdiet.
+                </p>
+            </div>
+            <div className="interaction-bar">
+                <button className="like-button">👍 いいね</button>
+                <button className="favorite-button">⭐ お気に入り</button>
+            </div>
+        </div>
+    );
+};
+
+export default Detail;

--- a/front/src/components/header/header.tsx
+++ b/front/src/components/header/header.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import "./header.scss";
+import { Link } from "react-router-dom";
 
 const Header = () => {
     return (
         <header className="header">
-            <a href="#" className="home-link">
+            <Link to="/" className="home-link">
                 ホーム
-            </a>
+            </Link>
             <div className="user-icon">
                 <img src="logo.png" alt="User Icon" />
             </div>

--- a/front/src/components/list/list.tsx
+++ b/front/src/components/list/list.tsx
@@ -10,6 +10,7 @@ import {
     Timestamp,
 } from "firebase/firestore";
 import useCollection from "../../hooks/useCollection";
+import { useNavigate } from "react-router-dom";
 
 interface Articles {
     id: string;
@@ -28,6 +29,8 @@ const List = () => {
     const collectionPostsRef: Query<DocumentData> = query(
         collection(db, "posts")
     );
+
+    const navigate = useNavigate();
 
     //カスタムHooks使用して、Firbaseからリアルタイムで取得
     const { data: articleData, error } = useCollection(collectionPostsRef);
@@ -68,13 +71,21 @@ const List = () => {
         return <div className="error-message">Error: {error}</div>;
     }
 
+    const goToArticleDetail = (articleId: string) => {
+        navigate(`/detail/${articleId}`);
+    };
+
     return (
         <div className="article-list">
             {/* ログアウトボタン仮置き、ブランチを切って再度修正予定 */}
             <button onClick={() => auth.signOut()}>ログアウト</button>
             {articles.map((article) => {
                 return (
-                    <div className="article-card" key={article.id}>
+                    <div
+                        className="article-card"
+                        key={article.id}
+                        onClick={() => goToArticleDetail(article.id)}
+                    >
                         <h2 className="article-title">{article.title}</h2>
                         <p className="article-tags">#タグ1 #タグ3</p>
                         <p className="article-author">


### PR DESCRIPTION
#### 対応したこと
* 記事一覧画面から記事詳細画面への遷移を実装
* 記事idに基づいて記事詳細を取得・表示
* Firestoreのpostsコレクションから以下のデータを取得し、表示
    - タイトル
    - 作者
    - 記事本文
* 記事本文をMarkdown形式でレンダリング
 
#### 対応予定
* タグ機能の実装
* いいねボタンの実装
* コメント機能の実装

#### 確認方法
1. #3のブランチに移動
2. 下記コマンドを実施
```
docker-compose up -d
```
3. localhost:3000にアクセス
4. ログインボタンを押下

#### 補足
* Firestoreに登録された記事本文の改行文字（`¥n`）がエスケープされるため、以下のコードを追加してエスケープ解除を行なった。
Typescript:detail.tsxの68行目
```
const processedValue = article.content.replace(/\\n/g,"\n");
```
