### PR TITLE
タグ検索時のバグを修正

### DIFF
--- a/front/src/components/list/list.tsx
+++ b/front/src/components/list/list.tsx
@@ -38,8 +38,7 @@ const List = () => {
     const collectionPostsRef: Query<DocumentData> = keyword.trim()
         ? query(
               collection(db, "posts"),
-              where("tags", "array-contains", keyword.trim()),
-              orderBy("createdAt", "desc")
+              where("tags", "array-contains", keyword.trim())
           )
         : query(collection(db, "posts"), orderBy("createdAt", "desc"));
 


### PR DESCRIPTION
#### 対応したこと
* タグ検索機能でタグを検索し、入力フォームからフォーカスを外した時に記事が表示されないバグを修正

#### 確認方法
* feature/#6ブランチに切り替え
* Dockerを起動し、下記コマンドを実行
```
docker-compose up -d 
```
* localhost:3000にアクセス
* ログインボタンを押下
* 記事一覧画面を表示
